### PR TITLE
Fixed `writegroup` Call

### DIFF
--- a/pyonep/onep.py
+++ b/pyonep/onep.py
@@ -251,4 +251,4 @@ class OnepV1():
     return self._call('write', cik, [rid, value, options], defer)
 
   def writegroup(self, cik, entries, defer=False):
-    return self._call('writegroup', cik, entries, defer)
+    return self._call('writegroup', cik, [entries], defer)


### PR DESCRIPTION
Calls to `writegroup` would always return 'invalid'. The issue was the extra `{}` in the arguments list that is intended for options in some calls, but `writegroup` does not take any options.
