### PR TITLE
Support 'activation log' in onep.provision.Provision.serialnumber_info().

### DIFF
--- a/pyonep/provision.py
+++ b/pyonep/provision.py
@@ -242,8 +242,8 @@ class Provision(object):
         return self._request(path, key, data, 'POST', self._manage_by_cik)
 
     def serialnumber_info(self, key, model, serialnumber, actvtn_log=False):
-        path = PROVISION_MANAGE_MODEL + model + '/' + serialnumber
         data = 'show=log' if actvtn_log else ''
+        path = PROVISION_MANAGE_MODEL + model + '/' + serialnumber
         return self._request(path, key, data, 'GET', self._manage_by_cik)
 
     def serialnumber_list(self, key, model, offset=0, limit=1000):

--- a/pyonep/provision.py
+++ b/pyonep/provision.py
@@ -241,9 +241,10 @@ class Provision(object):
         path = PROVISION_MANAGE_MODEL + model + '/' + serialnumber
         return self._request(path, key, data, 'POST', self._manage_by_cik)
 
-    def serialnumber_info(self, key, model, serialnumber):
+    def serialnumber_info(self, key, model, serialnumber, actvtn_log=False):
         path = PROVISION_MANAGE_MODEL + model + '/' + serialnumber
-        return self._request(path, key, '', 'GET', self._manage_by_cik)
+        data = 'show=log' if actvtn_log else ''
+        return self._request(path, key, data, 'GET', self._manage_by_cik)
 
     def serialnumber_list(self, key, model, offset=0, limit=1000):
         data = urlencode({'offset': offset, 'limit': limit})


### PR DESCRIPTION
Tested with following snippet:

```
$ python -c "from pyonep import provision; p = provision.Provision(manage_by_cik=False); print( p.serialnumber_info(<my_vendor_token>, <a_model>, <a_serial_number>, actvtn_log=True) )"
Status: 200, Reason: OK, Body: 1437693690,127.0.0.1,vendor=willcharlton&model=a_model&sn=0000000000001
1437694051,127.0.0.1,vendor=willcharlton&model=a_model&sn=0000000000001
1437694945,127.0.0.1,vendor=willcharlton&model=a_model&sn=0000000000001
```

Implements http://docs.exosite.com/provision/#provisionmanagemodelmodelsn : "GET - get activation log for serial number" endpoint of the Provisioning API.

New output shows the log of activations for a given serial number. I obfuscated the call to `serialnumber_info()` to protect the innocent, but vendor token was used in this example.